### PR TITLE
fix(white-label-broadcasting): customcard linking

### DIFF
--- a/src/pages/channel-api-white-label-broadcasting/overview.mdx
+++ b/src/pages/channel-api-white-label-broadcasting/overview.mdx
@@ -9,21 +9,21 @@ import CustomCard from '../../components/CustomCard/CustomCard.js';
   <Column colMd={4} colLg={4} noGutterSm style={{ marginBottom: '1px' }}>
     <CustomCard
       title="Customize player branding"
-      href="/channel-api-white-label-broadcasting/customize-player-branding"
+      href={withPrefix('/channel-api-white-label-broadcasting/customize-player-branding')}
       content="Control the branding of the player by uploading your own logo and removing the IBM watermark."
     ></CustomCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm style={{ marginBottom: '1px' }}>
     <CustomCard
       title="Hide viewer numbers in player"
-      href="/channel-api-white-label-broadcasting/hide-viewer-numbers-in-player"
+      href={withPrefix('/channel-api-white-label-broadcasting/hide-viewer-numbers-in-player')}
       content="The current and total number of viewers of a live channel will not be visible in the player."
     ></CustomCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
     <CustomCard
       title="Hide channel page"
-      href="/channel-api-white-label-broadcasting/hide-channel-page"
+      href={withPrefix('/channel-api-white-label-broadcasting/hide-channel-page')}
       content="If page lock is enabled, your channel and videos will not be found anywhere on video.ibm.com. Viewers will only be able to watch embedded players on external websites. "
     ></CustomCard>
   </Column>


### PR DESCRIPTION
Linking to Channel API White Label Broadcasting linkings in the CustomCards was broken.
Missing `withPrefix` func was added to CustomCards's href prop.