### PR TITLE
fix(gatsby-config): remove pathprefix

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,7 +5,7 @@ module.exports = {
       'Customize and control the viewing experience for your audience or create your own streaming applications, analyze engagement and telemetry data with the APIs and SDKs of the IBM Video Streaming platform.',
     keywords: 'gatsby,video,video streaming,developer,developers,sdk,api,player,ios,android,broadcast',
   },
-  pathPrefix: `/video-streaming-developer-docs`,
+  // pathPrefix: `/video-streaming-developer-docs`,
   // local build
   // pathPrefix: `/developers/public/`,
   plugins: [


### PR DESCRIPTION
details:
https://www.gatsbyjs.org/docs/how-gatsby-works-with-github-pages/#deploying-to-the-root-subdomain-and-using-a-custom-domain