### PR TITLE
fix: adjust mobile header alignment

### DIFF
--- a/src/gatsby-theme-carbon/components/HeaderShadow.module.scss
+++ b/src/gatsby-theme-carbon/components/HeaderShadow.module.scss
@@ -5,9 +5,9 @@
   text-decoration: none;
   left: 3rem;
   white-space: nowrap;
-  height: 3rem;
+  height: 1.375rem;
   border-top: 1px solid transparent;
-  display: flex;
+  display: table-cell;
   align-items: center;
 
   &:focus {

--- a/src/gatsby-theme-carbon/components/HeaderShadow.module.scss
+++ b/src/gatsby-theme-carbon/components/HeaderShadow.module.scss
@@ -8,7 +8,6 @@
   height: 1.375rem;
   border-top: 1px solid transparent;
   display: table-cell;
-  align-items: center;
 
   &:focus {
     outline: 2px solid $inverse-01;


### PR DESCRIPTION
Fixes #7 by adjusting the `height` to match the `line-height` and changing `display` to `table-cell`
