### PR TITLE
fix(auth-api): promote user claim in the token instead of username

### DIFF
--- a/src/pages/viewer-authentication-api-implementing-viewer-authentication.mdx
+++ b/src/pages/viewer-authentication-api-implementing-viewer-authentication.mdx
@@ -72,7 +72,7 @@ Example script in PHP for creating the authentication response when the authenti
 // We create the array of parameters.
 // The parameters can be anything.
 $userData = [
-    "username" => $_GET["user"],
+    "user" => $_GET["user"],
     "someString" => "someValue"
 ];
 


### PR DESCRIPTION
## Overview

- __Type:__
  - 🐛Fix
- __Ticket:__ No

## Problem

Clients are confused when their viewers don't show up in the viewer tracking. That's because the misleading "username" field in the example viewer auth implementation

## Solution

Dropped the username, let users use "user" instead

