### PR TITLE
fix(viewer-auth): expiration timestamp must be in seconds

### DIFF
--- a/src/pages/viewer-authentication-api-hash-lifetime-and-expiration.mdx
+++ b/src/pages/viewer-authentication-api-hash-lifetime-and-expiration.mdx
@@ -9,7 +9,7 @@ You can specify an expiration date for the hash. When the viewer returns to the 
 
 Expiration date must be
 
-- Specified in UNIX timestamp format
+- Specified as UNIX timestamp in seconds
 - Part of the hash by concatenating it to the rest of the parameters
 - Included in the response object as “hashExpire”.
 - JSON encoded as part of the response


### PR DESCRIPTION
## Overview

- __Type:__
  - 🐛Fix
- __Ticket:__ No

## Problem

For viewer auth adopters it's not always clear that the expiration should be in seconds, therefore they tend to use unix timestamp in milliseconds, that can lead to problems as we interpret this value as seconds.


## Solution

Explicitly instruct users to use unix timestamp in seconds

