### PR TITLE
feat(custom-domain): deploying to custom domain

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,9 +5,6 @@ module.exports = {
       'Customize and control the viewing experience for your audience or create your own streaming applications, analyze engagement and telemetry data with the APIs and SDKs of the IBM Video Streaming platform.',
     keywords: 'gatsby,video,video streaming,developer,developers,sdk,api,player,ios,android,broadcast',
   },
-  pathPrefix: `/video-streaming-developer-docs`,
-  // local build
-  // pathPrefix: `/developers/public/`,
   plugins: [
     {
       resolve: 'gatsby-plugin-manifest',

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+developers.video.ibm.com


### PR DESCRIPTION
## Overview

- __Type:__
  - ♻️Chore
- __Ticket:__ No

Deploying to custom domain `developers.video.ibm.com`:
- remove `pathPrefix` from `gatsby-config.js`
- add CNAME to static

See Gatsby Docs:
https://www.gatsbyjs.com/docs/how-gatsby-works-with-github-pages/#deploying-to-the-root-subdomain-and-using-a-custom-domain
