### PR TITLE
fix: channel api typo

### DIFF
--- a/src/pages/channel-api-video-management/upload-videos.mdx
+++ b/src/pages/channel-api-video-management/upload-videos.mdx
@@ -88,7 +88,7 @@ Don't forget to set your FTP client to binary file transfer mode, before uploadi
 A "file in place" signal tells to our server that it can start to process the file.
 
 ```
-PUT https://api.video.ibm.com/channels/{channel_id}/uploads/uploads/{video_id}.json
+PUT https://api.video.ibm.com/channels/{channel_id}/uploads/{video_id}.json
 ```
 
 ### Parameters
@@ -118,7 +118,7 @@ Possible error responses:
 Returns the status of processing the specific video.
 
 ```
-GET https://api.video.ibm.com/channels/{channel_id}/uploads/uploads/{video_id}.json
+GET https://api.video.ibm.com/channels/{channel_id}/uploads/{video_id}.json
 ```
 
 ### Parameters


### PR DESCRIPTION
## Overview

- __Type:__
  - 🐛Fix
- __Ticket:__ No

## Problem
Looks like a typo in the Channel API page double `uploads` in the url.


## Solution
Removed the second `uploads`
