### PR TITLE
feat(broadcasting-devices): core-2638 Typo in "Broadcasting devices" API

### DIFF
--- a/src/pages/channel-api-broadcast-settings/broadcasting-devices.mdx
+++ b/src/pages/channel-api-broadcast-settings/broadcasting-devices.mdx
@@ -135,7 +135,7 @@ Possible error responses:
 Revoke access to your channels from a broadcasting device.
 
 ```
-POST https://api.video.ibm.com/users/self/device-passwords/{user_name}.json
+DELETE https://api.video.ibm.com/users/self/device-passwords/{user_name}.json
 ```
 
 ### Parameters


### PR DESCRIPTION

- __Type:__
  -✨Fix
- __Ticket:__ [CORE-2638](<https://issues.ustream-adm.in/browse/CORE-2638>)

## Problem

_Typo in "Broadcasting devices" API documentation_


