### PR TITLE
PLAY-2164 document contentAvailable event

### DIFF
--- a/src/pages/player-api-usage.mdx
+++ b/src/pages/player-api-usage.mdx
@@ -293,6 +293,16 @@ Called when the currently loaded and played recorded video reaches its end.
 viewer.addListener('finished', callback);
 ```
 
+### contentAvailable
+
+Called when all metadata required to start playback is available.
+
+###### Example
+
+```js
+viewer.addListener('contentAvailable', callback);
+```
+
 ### playing
 
 Called when the currently loaded content playback is started or stopped. Sends data along the event:


### PR DESCRIPTION
## Overview

- __Type:__ 📚 Docs
- __Ticket:__ [PLAY-2164](https://issues.ustream-adm.in/browse/PLAY-2164)

## Problem
Documentation of contentAvailable event was missing.
