### PR TITLE
update player api version to 1.1.0 -> 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13498,9 +13498,9 @@
       }
     },
     "ibm-video-streaming-web-player-api": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ibm-video-streaming-web-player-api/-/ibm-video-streaming-web-player-api-1.1.0.tgz",
-      "integrity": "sha512-qcGl7+S0oI60cvQZ+egVv6s0DBbeNoj/XhceS51hFe/TGLsETsW82vWFkk5FqvqhvB3gUueaRvFIg6dpKHl0ZQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ibm-video-streaming-web-player-api/-/ibm-video-streaming-web-player-api-1.2.0.tgz",
+      "integrity": "sha512-WlArs8vtnPXHAt++CFun6LpK+QrOL/IrGEAkqxBHsXW5eHv0H5IIUgUguFpP3kFADXqfOu+2l5Van0lJCvjrow=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@carbon/icons-react": "^10.13.0",
     "gatsby": "^2.21.17",
     "gatsby-theme-carbon": "^1.24.1",
-    "ibm-video-streaming-web-player-api": "^1.1.0",
+    "ibm-video-streaming-web-player-api": "^1.2.0",
     "md5": "^2.2.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",


### PR DESCRIPTION
## Overview

- __Type:__ ♻️ Chore

## Problem

_What problem are you trying to solve?_
Web player api is out of date.

## Solution

_How did you solve the problem?_
Update api to new minor version. ([1.2.0](https://github.com/IBM/video-streaming-web-player-api/releases/tag/v1.2.0))
