### PR TITLE
docs(channel): add docs for new video upload API

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -33,6 +33,8 @@
     - title: Basic video management
       path: /channel-api-video-management/basic-video-management
     - title: Upload videos
+      path: /channel-api-video-management/upload-videos-new
+    - title: Upload videos (via FTP)
       path: /channel-api-video-management/upload-videos
     - title: Copy a video
       path: /channel-api-video-management/copy-a-video

--- a/src/pages/channel-api-video-management/upload-videos-new.mdx
+++ b/src/pages/channel-api-video-management/upload-videos-new.mdx
@@ -1,0 +1,157 @@
+---
+title: Upload videos
+description: Channel API Video management Upload videos
+---
+
+To upload a file you must do the following steps:
+
+1. Initiate an upload process by an API call. In the response you can find the video ID for the new upload and an upload ID that you will have to send with every request.
+2. Upload the video in 1MB parts. You might need to make several requests in this stage until all the parts of the video file have been uploaded.
+3. When the upload is finished, send an "upload complete" signal, which will start the processing of your video.
+4. Call the API to check the status of processing the video.
+
+## Initialize an upload
+
+Initiate the upload process.
+
+```
+POST https://api.video.ibm.com/v2/channels/{channel_id}/uploads.json
+```
+
+### Parameters
+
+The parameters for the POST request:
+
+| PARAMETER     | TYPE   | IMPORTANCE | DESCRIPTION                                                   |
+| ------------- | ------ | ---------- | ------------------------------------------------------------- |
+| `title`       | string | OPTIONAL   | Video title                                                   |
+| `description` | string | OPTIONAL   | Video description                                             |
+| `protect`     | string | OPTIONAL   | Video protection level. Supported values: `public`, `private` |
+
+### Success response
+
+Upon success a response with HTTP status "201 Created" is returned with the key-value pairs containing the video ID and upload ID.
+
+Example of a success response:
+
+```json
+{
+  "videoId": 1234567890,
+  "uploadId": "28691235606490ab81a8c0.96744426"
+}
+```
+
+### Error responses
+
+Possible error responses:
+
+| HTTP RESPONSE CODE      | ERROR VALUE             | ERROR CONDITIONS                                                                        |
+| ----------------------- | ----------------------- | --------------------------------------------------------------------------------------- |
+| 400 Bad Request         | `protect_level_invalid` | Invalid protect level has been sent                                                     |
+| 401 Unauthorized        | `invalid_token`         | The provided access token is missing, revoked, expired or malformed                     |
+| 403 Forbidden           | `lack_of_ownership`     | The API user is not allowed to manage the given channel                                 |
+| 404 Not Found           | `not_found`             | Channel was not found                                                                   |
+| 503 Service Unavailable |                         | There is a temporary error on the server which makes it impossible to serve the request |
+
+## Upload the video file
+
+In this stage you need to upload the video file in 1MB parts. You can find an example of this in the downloadable PHP sample code: https://developers.video.ibm.com/channel-api-php-sample-code
+
+Before you start uploading the parts, you will need to calculate the total number of parts and the total size of the file.
+
+To upload one part send a multi-part file request to this endpoint:
+
+```
+POST https://api.video.ibm.com/v2/channels/{channel_id}/uploads/{video_id}/part.json
+```
+
+### Parameters
+
+The parameters for the POST request:
+
+| PARAMETER        | TYPE   | IMPORTANCE | DESCRIPTION                                                   |
+| ---------------- | ------ | ---------- | ------------------------------------------------------------- |
+| `uploadId`       | string | REQUIRED   | The upload ID from the init response                          |
+| `partIndex`      | int    | REQUIRED   | The index of the current part                                 |
+| `totalPartCount` | int    | REQUIRED   | The total number of parts that will be uploaded               |
+| `totalFileSize`  | int    | REQUIRED   | The total size of the video file                              |
+| `file`           | binary | REQUIRED   | The current file part's content                               |
+
+### Success response
+
+Upon success a response with HTTP status "200 OK" is returned with the key-value pairs containing the video ID and upload ID.
+
+### Error responses
+
+Possible error responses:
+
+| HTTP RESPONSE CODE      | ERROR VALUE             | ERROR CONDITIONS                                                                        |
+| ----------------------- | ----------------------- | --------------------------------------------------------------------------------------- |
+| 400 Bad Request         |                         | Invalid parameters. Look at the returned hint value for the exact error.                |
+| 401 Unauthorized        | `invalid_token`         | The provided access token is missing, revoked, expired or malformed                     |
+| 403 Forbidden           | `lack_of_ownership`     | The API user is not allowed to manage the given channel                                 |
+| 404 Not Found           | `not_found`             | Channel or video was not found                                                          |
+| 413 Payload too large   | `file_too_large`        | The incoming file is larger than 4GB                                                    |
+| 503 Service Unavailable |                         | There is a temporary error on the server which makes it impossible to serve the request |
+
+
+## Send "upload completed" signal
+
+The "upload completed" signal tells to our server that it can start to process the file.
+
+```
+POST https://api.video.ibm.com/v2/channels/{channel_id}/uploads/{video_id}/completed.json
+```
+
+### Parameters
+
+The parameters for the POST request:
+
+| PARAMETER  | TYPE   | IMPORTANCE | DESCRIPTION                          |
+| ---------- | ------ | ---------- | ------------------------------------ |
+| `uploadId` | string | REQUIRED   | The upload ID from the init response |
+
+### Success response
+
+Upon success, a response with HTTP status "200 OK" is returned.
+
+### Error responses
+
+Possible error responses:
+
+| HTTP RESPONSE CODE      | ERROR VALUE | ERROR CONDITIONS                                                                        |
+| ----------------------- | ----------- | --------------------------------------------------------------------------------------- |
+| 400 Bad Request         |             | Invalid parameters. Look at the returned hint value for the exact error.                |
+| 401 Unauthorized        |             | The provided access token is missing, revoked, expired or malformed                     |
+| 404 Not Found           | `not_found` | Channel or video was not found                                                          |
+| 503 Service Unavailable |             | There is a temporary error on the server which makes it impossible to serve the request |
+
+### Check status of processing
+
+Returns the status of processing the specific video.
+
+```
+GET https://api.video.ibm.com/channels/{channel_id}/uploads/{video_id}.json
+```
+
+### Parameters
+
+This request has no parameters.
+
+### Success response
+
+Upon success a response with HTTP status "200 OK" is returned with a key-value pair.
+
+| KEY      | TYPE   | DESCRIPTION                                                                                                              |
+| -------- | ------ | ------------------------------------------------------------------------------------------------------------------------ |
+| `status` | string | The current status. Possible values: `initiated`, `transferred`, `queued`, `pending`, `transcoding`, `complete`, `error` |
+
+### Error responses
+
+Possible error responses:
+
+| HTTP RESPONSE CODE      | ERROR VALUE | ERROR CONDITIONS                                                                        |
+| ----------------------- | ----------- | --------------------------------------------------------------------------------------- |
+| 401 Unauthorized        |             | The provided access token is missing, revoked, expired or malformed                     |
+| 404 Not Found           | `not_found` | Channel was not found                                                                   |
+| 503 Service Unavailable |             | There is a temporary error on the server which makes it impossible to serve the request |

--- a/src/pages/channel-api-video-management/upload-videos.mdx
+++ b/src/pages/channel-api-video-management/upload-videos.mdx
@@ -1,7 +1,9 @@
 ---
-title: Upload videos
-description: Channel API Video management Upload videos
+title: Upload videos (via FTP)
+description: Channel API Video management Upload videos (via FTP)
 ---
+
+**IMPORTANT:** *Please note that this upload method is deprecated and will be discontinued later this year. We encourage yout to switch over to our new upload method found here: https://developers.video.ibm.com/channel-api-video-management/upload-videos-new*
 
 Videos can be uploaded by FTP. To upload a file you must do the following steps:
 


### PR DESCRIPTION
## Overview

- __Type:__
  - 📚Docs
- __Ticket:__ No

## Changes

- Marking the old FTP upload deprecated and suggesting using the new video upload in the future.
- Added documentation for the new video upload method.
