### PR TITLE
feat(player-sdk): add deprecation notice to iOS ad integration

### DIFF
--- a/src/pages/player-sdk-ios/ad-integration.mdx
+++ b/src/pages/player-sdk-ios/ad-integration.mdx
@@ -3,6 +3,10 @@ title: Ad Integration
 description: Ad Integration
 ---
 
+**IMPORTANT NOTICE**
+*Ad integration has been deprecated in version 1.9 of the SDK and it is scheduled to be removed in the next upcoming MINOR version (1.10).
+Support is no longer provided for this component of the Player SDK.*
+
 ## Introduction
 
 The SDK supports serving ads with Google's DoubleClick for Publishers (DFP) service.


### PR DESCRIPTION
## Overview

- __Type:__
  - ✨Feat
- __Ticket:__ [IOS-1164](<https://issues.ustream-adm.in/browse/IOS-1164>)

## Problem

iOS Player SDK Ad integration is no longer supported.


## Solution

Added a deprecation alert to the related doc section.



