### PR TITLE
fix: use session in the example instead of a query param

### DIFF
--- a/src/pages/viewer-authentication-api-implementing-viewer-authentication.mdx
+++ b/src/pages/viewer-authentication-api-implementing-viewer-authentication.mdx
@@ -72,7 +72,7 @@ Example script in PHP for creating the authentication response when the authenti
 // We create the array of parameters.
 // The parameters can be anything.
 $userData = [
-    "user" => $_GET["user"],
+    "user" => $_SESSION["user"],
     "someString" => "someValue"
 ];
 


### PR DESCRIPTION
## Overview

- __Type:__
  - 🐛Fix

## Problem

The `$_GET` can be confusing in the viewer auth example. Users assume that they will get a `user` query parameter on their auth endpoint.

## Solution

Using `$_SESSION` suggests, that they have to read their own user session, and pass back the user identifier in the token