### PR TITLE
PLAY-2487 New params and outsourcing Params to separate page

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -183,6 +183,9 @@
 - title: Usage
   pages:
     - path: /player-api-usage
+- title: URL Parameters
+  pages:
+    - path: /player-api-url-parameters
 - title: Examples
   pages:
     - title: Basic embed

--- a/src/pages/player-api-url-parameters.mdx
+++ b/src/pages/player-api-url-parameters.mdx
@@ -32,7 +32,7 @@ The default behavior of the player can be modified by extending the src URL with
 | showpopout      | Shows the Popout button in the control bar. Viewers can view the player in a browser popout window.                                                                         | true/false     | false   |
 | volume          | Set volume for playback as a percentage of the max volume. Overrides the default volume (100).                                                                              | 0-100          | 100     |
 
-## Hide UI elements with URL parameters
+## Hide individual UI elements with URL parameters
 
 Many UI elements on the player can be hidden from viewers by using URL parameters. These parameters do not need values to work.
 

--- a/src/pages/player-api-url-parameters.mdx
+++ b/src/pages/player-api-url-parameters.mdx
@@ -1,0 +1,60 @@
+---
+title: URL Parameters
+description: Query Parameters Used with The Player
+---
+
+## Overview
+
+There are a lot of options to configure the feature set and behavior during player initialization. The player looks for URL query parameters included in the src of the Player iframe to set these prefences to the whole playback session.
+
+### Example
+
+This example shows an iframe in which the player would hide the title bar, the LIVE badge and the viewer numbers from viewers:
+
+```html
+<iframe id="PlayerIframe" src="https://video.ibm.com/embed/1524?html5ui?hideTitle&hideLiveBadge&hideViewerNumbers" width="640" height="480" allowfullscreen webkitallowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
+```
+
+## URL parameters to change the behavior of the Player
+
+The default behavior of the player can be modified by extending the src URL with any of the following parameters:
+
+| Parameter       | Effect                                                                                                                                                                      | Values         | Default |
+|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|---------|
+| allowfullscreen | Enables full-screen. False value makes the full-screen button inactive.                                                                                                     | true/false     | true    |
+| api-target-origin | Origin of the page where player api is included. Use `encodeURIComponent` to URL encode origin. This parameter is only required in case of SSO authentication.                                                                              | URL encoded origin e.g. output of `encodeURIComponent('https://video.ibm.com')`        | N/A     |
+| autoplay        | Starts video playback automatically. Browser settings are stronger and may override the value of this parameter.                                                            | true/false     | false   |
+| controls        | When set to false it hides all UI elements.                                                                                                                                 | true/false     | true    |
+| forced-quality  | Turns off the automatic quality selection and selects the appropriate quality. Low is the smallest available quality, high is the largest and med is the middlemost choice. | low, med, high | N/A     |
+| initial-quality | Sets the initial quality for the automatic quality selection. The quality selection logic is still turned on and can switch to another quality after playback is started.   | low, med, high | N/A     |
+| showtitle       | Shows title and viewer count information inside the player area.                                                                                                            | true/false     | true    |
+| showtheatre     | Shows the Theater button in an embedded player. Only works with the video.ibm.com sidebar, used internally.                                                                 | true/false     | false   |
+| showpopout      | Shows the Popout button in the control bar. Viewers can view the player in a browser popout window.                                                                         | true/false     | false   |
+| volume          | Set volume for playback as a percentage of the max volume. Overrides the default volume (100).                                                                              | 0-100          | 100     |
+
+## Hide UI elements with URL parameters
+
+Many UI elements on the player can be hidden from viewers by using URL parameters. These parameters do not need values to work.
+
+| Parameter         | Effect                                                                                                              |
+|-------------------|---------------------------------------------------------------------------------------------------------------------|
+| hideAudioSwitch   | Hides the audio selector icon of multi-language videos                                                              |
+| hidePlayScreen    | Hides the play screen after initial player load (does not cause autoplay)                                           |
+| hideCaptionSearch | Hides the magnifying glass icon for Speach Search in Videos with CC                                                 |
+| hideChapters      | Hides the Chapter Selector panel icon and the Chapter Markings from the seekbar                                     |
+| hideCustomLogo    | Hides the uploaded Custom Branding Logo from the player                                                             |
+| hideCTA           | Disables CTA overlays. Rely on the liveCtaUpdate event to trigger your own CTA.                                     |
+| hideLogo          | Hides the IBM logo from the player                                                                                  |
+| hideShare         | Hides the Share icon from the player                                                                                |
+| hideFacebook      | Hides the Facebook option from the Share menu                                                                       |
+| hideTwitter       | Hides the Twitter option from the Share menu                                                                        |
+| hideCopyLink      | Hides the "Copy Link" option from the Share menu                                                                    |
+| hideEmbedCode     | Hides the "Embed Code" option from the Share menu                                                                   |
+| hideCC            | Hides the CC selector icon from the player controls (does not affect displaying CC set to appear by default)        |
+| hideTitle         | Hides the broadcast/channel title from the top of the player                                                        |
+| hideViewerNumbers | Hides the display of the current and total viewership from the top of the player                                    |
+| hideLiveBadge     | Hides the "LIVE" badge from the player                                                                              |
+| hideReplayBadge   | Hides the "REPLAY" badge from the player                                                                            |
+| hideFullscreen    | Hides the full-screen icon from the controls                                                                        |
+| hidePlaybackSpeed | Hides the playback speed icon from the controls                                                                     |
+| hideSeekbar       | Hides the seekbar from video controls, viewers can not seek in videos but can pause/play and control other features |

--- a/src/pages/player-api-usage.mdx
+++ b/src/pages/player-api-usage.mdx
@@ -32,55 +32,13 @@ npm install ibm-video-streaming-web-player-api
 Create an instance of the Embed API by providing the ID of the iframe. The iframe code should look like this:
 
 ```html
-<iframe id="PlayerIframe" src="https://video.ibm.com/embed/1524?html5ui" width="640" height="480" allowfullscreen webkitallowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
+<iframe id="PlayerIframe" src="https://video.ibm.com/embed/1524" width="640" height="480" allowfullscreen webkitallowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
 ```
 ```js
 let viewer = PlayerAPI('PlayerIframe');
 ```
 
-## URL parameters
-
-The default behavior of the player can be modified by extending the src URL with any of the following parameters:
-
-| Parameter       | Effect                                                                                                                                                                      | Values         | Default |
-|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------|---------|
-| allowfullscreen | Enables full-screen. False value makes the full-screen button inactive.                                                                                                     | true/false     | true    |
-| api-target-origin | Origin of the page where player api is included. Use `encodeURIComponent` to URL encode origin. This parameter is only required in case of SSO authentication.                                                                              | URL encoded origin e.g. output of `encodeURIComponent('https://video.ibm.com')`        | N/A     |
-| autoplay        | Starts video playback automatically. Browser settings are stronger and may override the value of this parameter.                                                            | true/false     | false   |
-| controls        | When set to false it hides all UI elements.                                                                                                                                 | true/false     | true    |
-| forced-quality  | Turns off the automatic quality selection and selects the appropriate quality. Low is the smallest available quality, high is the largest and med is the middlemost choice. | low, med, high | N/A     |
-| initial-quality | Sets the initial quality for the automatic quality selection. The quality selection logic is still turned on and can switch to another quality after playback is started.   | low, med, high | N/A     |
-| showtitle       | Shows title and viewer count information inside the player area.                                                                                                            | true/false     | true    |
-| showtheatre     | Shows the Theater button in an embedded player. Only works with the video.ibm.com sidebar, used internally.                                                                 | true/false     | false   |
-| showpopout      | Shows the Popout button in the control bar. Viewers can view the player in a browser popout window.                                                                         | true/false     | false   |
-| volume          | Set volume for playback as a percentage of the max volume. Overrides the default volume (100).                                                                              | 0-100          | 100     |
-
-### Hide UI elements with URL parameters
-
-Many UI elements on the player can be hidden from viewers by using URL parameters. These parameters do not need values to work.
-
-| Parameter         | Effect                                                                                                              |
-|-------------------|---------------------------------------------------------------------------------------------------------------------|
-| hideAudioSwitch   | Hides the audio selector icon of multi-language videos                                                              |
-| hidePlayScreen    | Hides the play screen after initial player load (does not cause autoplay)                                           |
-| hideCaptionSearch | Hides the magnifying glass icon for Speach Search in Videos with CC                                                 |
-| hideChapters      | Hides the Chapter Selector panel icon and the Chapter Markings from the seekbar                                     |
-| hideCustomLogo    | Hides the uploaded Custom Branding Logo from the player                                                             |
-| hideCTA           | Disables CTA overlays. Rely on the liveCtaUpdate event to trigger your own CTA.                                     |
-| hideLogo          | Hides the IBM logo from the player                                                                                  |
-| hideShare         | Hides the Share icon from the player                                                                                |
-| hideFacebook      | Hides the Facebook option from the Share menu                                                                       |
-| hideTwitter       | Hides the Twitter option from the Share menu                                                                        |
-| hideCopyLink      | Hides the "Copy Link" option from the Share menu                                                                    |
-| hideEmbedCode     | Hides the "Embed Code" option from the Share menu                                                                   |
-| hideCC            | Hides the CC selector icon from the player controls (does not affect displaying CC set to appear by default)        |
-| hideTitle         | Hides the broadcast/channel title from the top of the player                                                        |
-| hideViewerNumbers | Hides the display of the current and total viewership from the top of the player                                    |
-| hideLiveBadge     | Hides the "LIVE" badge from the player                                                                              |
-| hideReplayBadge   | Hides the "REPLAY" badge from the player                                                                            |
-| hideFullscreen    | Hides the full-screen icon from the controls                                                                        |
-| hidePlaybackSpeed | Hides the playback speed icon from the controls                                                                     |
-| hideSeekbar       | Hides the seekbar from video controls, viewers can not seek in videos but can pause/play and control other features |
+Content Owners can customize their Player's user experience by using query parameters in the src url above. The list of available URL parameters and their effects can be found here: [URL Parameters](/player-api-url-parameters) 
 
 ## Method Calls
 

--- a/src/pages/player-api-usage.mdx
+++ b/src/pages/player-api-usage.mdx
@@ -49,10 +49,38 @@ The default behavior of the player can be modified by extending the src URL with
 | autoplay        | Starts video playback automatically. Browser settings are stronger and may override the value of this parameter.                                                            | true/false     | false   |
 | controls        | When set to false it hides all UI elements.                                                                                                                                 | true/false     | true    |
 | forced-quality  | Turns off the automatic quality selection and selects the appropriate quality. Low is the smallest available quality, high is the largest and med is the middlemost choice. | low, med, high | N/A     |
-| hideCTA         | Disables CTA overlays. Use liveCtaUpdate event to build your own.                                                                                                           | true/false     | false   |
 | initial-quality | Sets the initial quality for the automatic quality selection. The quality selection logic is still turned on and can switch to another quality after playback is started.   | low, med, high | N/A     |
 | showtitle       | Shows title and viewer count information inside the player area.                                                                                                            | true/false     | true    |
+| showtheatre     | Shows the Theater button in an embedded player. Only works with the video.ibm.com sidebar, used internally.                                                                 | true/false     | false   |
+| showpopout      | Shows the Popout button in the control bar. Viewers can view the player in a browser popout window.                                                                         | true/false     | false   |
 | volume          | Set volume for playback as a percentage of the max volume. Overrides the default volume (100).                                                                              | 0-100          | 100     |
+
+### Hide UI elements with URL parameters
+
+Many UI elements on the player can be hidden from viewers by using URL parameters. These parameters do not need values to work.
+
+| Parameter         | Effect                                                                                                              |
+|-------------------|---------------------------------------------------------------------------------------------------------------------|
+| hideAudioSwitch   | Hides the audio selector icon of multi-language videos                                                              |
+| hidePlayScreen    | Hides the play screen after initial player load (does not cause autoplay)                                           |
+| hideCaptionSearch | Hides the magnifying glass icon for Speach Search in Videos with CC                                                 |
+| hideChapters      | Hides the Chapter Selector panel icon and the Chapter Markings from the seekbar                                     |
+| hideCustomLogo    | Hides the uploaded Custom Branding Logo from the player                                                             |
+| hideCTA           | Disables CTA overlays. Rely on the liveCtaUpdate event to trigger your own CTA.                                     |
+| hideLogo          | Hides the IBM logo from the player                                                                                  |
+| hideShare         | Hides the Share icon from the player                                                                                |
+| hideFacebook      | Hides the Facebook option from the Share menu                                                                       |
+| hideTwitter       | Hides the Twitter option from the Share menu                                                                        |
+| hideCopyLink      | Hides the "Copy Link" option from the Share menu                                                                    |
+| hideEmbedCode     | Hides the "Embed Code" option from the Share menu                                                                   |
+| hideCC            | Hides the CC selector icon from the player controls (does not affect displaying CC set to appear by default)        |
+| hideTitle         | Hides the broadcast/channel title from the top of the player                                                        |
+| hideViewerNumbers | Hides the display of the current and total viewership from the top of the player                                    |
+| hideLiveBadge     | Hides the "LIVE" badge from the player                                                                              |
+| hideReplayBadge   | Hides the "REPLAY" badge from the player                                                                            |
+| hideFullscreen    | Hides the full-screen icon from the controls                                                                        |
+| hidePlaybackSpeed | Hides the playback speed icon from the controls                                                                     |
+| hideSeekbar       | Hides the seekbar from video controls, viewers can not seek in videos but can pause/play and control other features |
 
 ## Method Calls
 

--- a/src/pages/player-api-usage.mdx
+++ b/src/pages/player-api-usage.mdx
@@ -38,7 +38,7 @@ Create an instance of the Embed API by providing the ID of the iframe. The ifram
 let viewer = PlayerAPI('PlayerIframe');
 ```
 
-Content Owners can customize their Player's user experience by using query parameters in the src url above. The list of available URL parameters and their effects can be found here: [URL Parameters](/player-api-url-parameters) 
+Content Owners can customize their Player's user experience by [using query parameters](https://developer.mozilla.org/en-US/docs/Learn/Common_questions/What_is_a_URL#parameters) in the src url above. The list of available URL parameters and their effects can be found here: [URL Parameters](/player-api-url-parameters) 
 
 ## Method Calls
 


### PR DESCRIPTION
## Overview

- __Type:__
 - 📚Docs
- __Ticket:__ [PLAY-2487](<https://issues.ustream-adm.in/browse/PLAY-2487>)

## Problem

Extend documentation with new URL Params
Outsource URL Parameters from Embed API Usage docs

## Solution

Documentation
