### PR TITLE
docs(player url parameters): fix example url

### DIFF
--- a/src/pages/player-api-url-parameters.mdx
+++ b/src/pages/player-api-url-parameters.mdx
@@ -12,7 +12,7 @@ There are a lot of options to configure the feature set and behavior during play
 This example shows an iframe in which the player would hide the title bar, the LIVE badge and the viewer numbers from viewers:
 
 ```html
-<iframe id="PlayerIframe" src="https://video.ibm.com/embed/1524?html5ui?hideTitle&hideLiveBadge&hideViewerNumbers" width="640" height="480" allowfullscreen webkitallowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
+<iframe id="PlayerIframe" src="https://video.ibm.com/embed/1524?hideTitle&hideLiveBadge&hideViewerNumbers" width="640" height="480" allowfullscreen webkitallowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
 ```
 
 ## URL parameters to change the behavior of the Player


### PR DESCRIPTION
## Overview

- __Type:__

  - 📚Docs
  - 🐛Fix
  
- __Ticket:__ No

## Problem

The src in the Example contained malformed url which had an older, unused parameter left in it

## Solution

did cleanup on the parameter list
checked the url
