### PR TITLE
update player-api-url-parameters with new param

### DIFF
--- a/src/pages/player-api-url-parameters.mdx
+++ b/src/pages/player-api-url-parameters.mdx
@@ -31,6 +31,7 @@ The default behavior of the player can be modified by extending the src URL with
 | showtheatre     | Shows the Theater button in an embedded player. Only works with the video.ibm.com sidebar, used internally.                                                                 | true/false     | false   |
 | showpopout      | Shows the Popout button in the control bar. Viewers can view the player in a browser popout window.                                                                         | true/false     | false   |
 | volume          | Set volume for playback as a percentage of the max volume. Overrides the default volume (100).                                                                              | 0-100          | 100     |
+| slideShowSpeed  | Set the duration (in seconds) an off-air image is shown if an off-air image slideshow is set for a channel.                                                                 | 1,2,3,...      | 5       |   
 
 ## Hide individual UI elements with URL parameters
 


### PR DESCRIPTION
## Overview

- __Type:__
  - 📚Docs

- __Ticket:__ [PLAY-2527](https://issues.ustream-adm.in/browse/PLAY-2527)

## Problem

There is a new query parameter available for the web Player which is not yet documented

## Solution

Added the parameter, short description, value range and default value to the last row of the URL parameter table


## Other changes (e.g. bug fixes, UI tweaks, small refactors)
--