### PR TITLE
PLAY-2541 document webkitEnterFullscreen

### DIFF
--- a/src/pages/player-api-usage.mdx
+++ b/src/pages/player-api-usage.mdx
@@ -137,6 +137,16 @@ viewer.callMethod('cc', 1); //enables the closed caption with index 1
 viewer.callMethod('cc', -1); //disables the closed caption
 ```
 
+### webkitEnterFullscreen (iOS)
+
+Calls `webkitEnterFullscreen` on the `HTMLVideoElement` to access the video's native fullscreen UI.
+
+###### Example
+
+```js
+viewer.callMethod('webkitEnterFullscreen');
+```
+
 ## getProperty
 
 Retrieves a property of the embed player. This method is __asynchronous__, the data will be passed to a callback function, given as argument.
@@ -482,6 +492,7 @@ Returns an object:
 Available error type(s):
 
 - `autoplayRejected`
+- `webkitEnterFullscreenRejected`
 
 ###### Example
 
@@ -492,16 +503,11 @@ viewer.addListener('error', function(type, errorEvent) {
             // TODO: display fallback button
             console.log(errorEvent.message);
             break;
+        case 'webkitEnterFullscreenRejected':
+            // TODO: browser prevented the request, user gesture is needed
+            console.log(errorEvent.message);
+            break;
         // no default
     }
 });
-```
-
-Example autoplayRejected error:
-
-```json
-{
-    "name": "autoplayRejected",
-    "message": "detailed error message"
-}
 ```


### PR DESCRIPTION
## Overview

- __Type:__ ✨Feat
- __Ticket:__ PLAY-2541

## Problem

_What problem are you trying to solve?_
There is no current way for our users to go fullscreen on iOS, because on iOS only $video.webkitEnterFullscreen is supported and it opens the default video UI.

## Solution

_How did you solve the problem?_
Add new `webkitEnterFullscreen` command.
Add new `webkitEnterFullscreenRejected` event for covering cases when the browser prevents this action.
