### PR TITLE
PLAY-2109 remove fullscreen button

### DIFF
--- a/src/pages/player-api-examples/fullscreen-functionality.mdx
+++ b/src/pages/player-api-examples/fullscreen-functionality.mdx
@@ -16,7 +16,7 @@ Third party player controls should implement the fullscreen functionality on the
 ### Example
 
 <EmbedPlayer
-  src="https://www.ustream.tv/embed/1524?hideFullscreen"
+  src="https://video.ibm.com/embed/1524?hideFullscreen"
   controls={['fullscreen']}
 />
 
@@ -35,11 +35,11 @@ document.addEventListener("MSFullscreenChange", changeHandler, false);
 fullScreenBtn.addEventListener('click',onFullScreenBtnClick);
 
 // check if the current state is fullscreen or not
-function isFullScreen () {
+function isFullScreen() {
   return document.fullScreen ||
     document.webkitIsFullScreen ||
     document.mozfullScreen ||
-	document.msFullscreenElement;
+    document.msFullscreenElement;
 }
 
 // change everything on other change events too
@@ -95,18 +95,18 @@ function onFullScreenBtnClick () {
 ### CSS
 
 ```css
-#Viewer {
+#Container {
   position: relative;
   width: 640px;
   height: 390px;
 }
 
-#Viewer.fullscreen {
+#Container.fullscreen {
   width: 100%;
   height: 100%;
 }
 
-#FullScreen {
+#fullScreenBtn {
   cursor: pointer;
   position: absolute;
   bottom: 10px;

--- a/src/pages/player-api-examples/fullscreen-functionality.mdx
+++ b/src/pages/player-api-examples/fullscreen-functionality.mdx
@@ -16,7 +16,7 @@ Third party player controls should implement the fullscreen functionality on the
 ### Example
 
 <EmbedPlayer
-  src="https://www.ustream.tv/embed/1524"
+  src="https://www.ustream.tv/embed/1524?hideFullscreen"
   controls={['fullscreen']}
 />
 
@@ -82,7 +82,7 @@ function onFullScreenBtnClick () {
   <iframe
     id="UstreamIframe"
     width="100%" height="100%"
-    src="https://www.ustream.tv/embed/1524?controls=false"
+    src="https://www.ustream.tv/embed/1524?hideFullscreen"
     frameborder="0"
     allowfullscreen
     referrerpolicy="no-referrer-when-downgrade"


### PR DESCRIPTION
## Overview

- __Type:__ 🐛Fix
- __Ticket:__ PLAY-2109

## Problem

_What problem are you trying to solve?_
In the fullscreen example we had the built in fullscreen button, but its state didn't update with  the custom fullscreen functionality.

## Solution

_How did you solve the problem?_
I used the new hideFullscreen param to hide the built-in button.