### PR TITLE
docs: add "loop" to the list of query params

### DIFF
--- a/src/pages/player-api-url-parameters.mdx
+++ b/src/pages/player-api-url-parameters.mdx
@@ -31,7 +31,8 @@ The default behavior of the player can be modified by extending the src URL with
 | showtheatre     | Shows the Theater button in an embedded player. Only works with the video.ibm.com sidebar, used internally.                                                                 | true/false     | false   |
 | showpopout      | Shows the Popout button in the control bar. Viewers can view the player in a browser popout window.                                                                         | true/false     | false   |
 | volume          | Set volume for playback as a percentage of the max volume. Overrides the default volume (100).                                                                              | 0-100          | 100     |
-| slideShowSpeed  | Set the duration (in seconds) an off-air image is shown if an off-air image slideshow is set for a channel.                                                                 | 1,2,3,...      | 5       |   
+| slideShowSpeed  | Set the duration (in seconds) an off-air image is shown if an off-air image slideshow is set for a channel.                                                                 | 1,2,3,...      | 5       |
+| loop            | Playback of current video will continue from the beginning after it's ended, automatically.                                                                                 | nothing        | N/A     |
 
 ## Hide individual UI elements with URL parameters
 


### PR DESCRIPTION
## Overview
This change only contains 1 added parameter to the table of Player URL Parameters. The new loop parameter is already released to GA.

- __Type:__
  - 📚Docs

- __Ticket:__ [PLAY-2648](<https://issues.ustream-adm.in/browse/PLAY-2648>)

## Problem

People wanted to play their embed videos looped

## Solution

Tell them the magical url parameter with which they can achieve their goal: ?loop
