### PR TITLE
chore(deploy): use allowed workflow for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,37 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: enriikke/gatsby-gh-pages-action@v2.2.0
+      - uses: actions/checkout@v3
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
         with:
-          access-token: ${{ secrets.DEV_DOCS_TOKEN }}
-          deploy-branch: gh-pages
+          node-version: 16.x
+      - name: Install packages
+        run: npm ci
+      - name: Gatsby Cache Folder
+        uses: actions/cache@v3
+        id: gatsby-cache-folder
+        with:
+          path: .cache
+          key: ${{ runner.os }}-cache-gatsby
+          restore-keys: |
+            ${{ runner.os }}-cache-gatsby
+      - name: Gatsby Public Folder
+        uses: actions/cache@v3
+        id: gatsby-public-folder
+        with:
+          path: public/
+          key: ${{ runner.os }}-public-gatsby
+          restore-keys: |
+            ${{ runner.os }}-public-gatsby
+      - name: Build site
+        run: npm run build
+      - name: Add CNAME record
+        run: |
+          echo 'developers.video.ibm.com' > public/CNAME
+      # - name: Deploy
+      #   run: |
+      #     git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+      #     npx gh-pages -d public -u "github-actions <github-actions@github.com>"
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.DEV_DOCS_TOKEN }}


### PR DESCRIPTION
## Overview

- __Type:__
  - ♻️Chore
- __Ticket:__ [cobra-5554](<https://issues.ustream-adm.in/browse/cobra-5554>)

## Problem

Current Github actions workflow is not allowed for deploy.
I changed it to be IBM compatible.
Replace Watson Media to IBM Video Streaming at Product Portfolio link.