### PR TITLE
chore(deploy): use allowed workflow for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Add CNAME record
         run: |
           echo 'developers.video.ibm.com' > public/CNAME
-      # - name: Deploy
-      #   run: |
-      #     git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-      #     npx gh-pages -d public -u "github-actions <github-actions@github.com>"
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.DEV_DOCS_TOKEN }}
+      - name: Deploy
+        run: |
+          git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+          npx gh-pages -d public -u "github-actions <github-actions@github.com>"
+        env:
+          GITHUB_TOKEN: ${{ secrets.DEV_DOCS_TOKEN }}


### PR DESCRIPTION
## Overview

- __Type:__
  - ♻️Chore
- __Ticket:__ [cobra-5554](<https://issues.ustream-adm.in/browse/cobra-5554>)

## Problem

Current Github actions workflow is not allowed for deploy.
I changed it to be IBM compatible.
Replace Watson Media to IBM Video Streaming at Product Portfolio link.