### PR TITLE
chore(dependabot): cobra-7554 add ignore rule for gatsby

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,7 +1,3 @@
-# Example configuration file that:
-#  - Ignores lodash dependency
-#  - Disables version-updates
-
 version: 2
 updates:
   - package-ecosystem: "npm"

--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,12 @@
+# Example configuration file that:
+#  - Ignores lodash dependency
+#  - Disables version-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "gatsby"


### PR DESCRIPTION
## Overview

- __Type:__
  - ♻️Chore
- __Ticket:__ [cobra-7554]

## Problem

_What problem are you trying to solve?_
We can't update gatsby dependency yet to version 5, because gatsby-theme-carbon is not yey compatible with it

## Solution

_How did you solve the problem?_
I added a depandabot rule to ignore gatsby package

