### PR TITLE
feat(video-download): cobra-7574 extend download expiration

### DIFF
--- a/src/pages/channel-api-video-management/download-your-videos.mdx
+++ b/src/pages/channel-api-video-management/download-your-videos.mdx
@@ -58,7 +58,7 @@ The downloadable version of a video is not always available, and you have to req
 2. Poll the same API resource for status updates.
 3. Use the value of the `download_url` property as soon as it is available.
 
-You have 24 hours to download the video file  after it becomes available. Please refer to the property `expires_at` for the proper timing.
+You have 365 days to download the video file  after it becomes available. Please refer to the property `expires_at` for the proper timing.
 
 ```
 POST https://api.video.ibm.com/videos/{video_id}/downloadable/{video_format}.json


### PR DESCRIPTION
## Overview

- __Type:__
  - ✨Feat
- __Ticket:__ [COBRA-7574]

## Problem

We extended the download expiration time from 24 hours to 365 days

## Solution

We changed the 'You have 24 hours to download the video file' to 'You have 365 days to download the video file
