### PR TITLE
fix(videos): adjust paging response examples

### DIFF
--- a/src/pages/channel-api-video-management/basic-video-management.mdx
+++ b/src/pages/channel-api-video-management/basic-video-management.mdx
@@ -108,8 +108,8 @@ The paging information can be found under the `paging` key. Example:
 ```json
 {
   "paging": {
-    "previous": "https://api.video.ibm.com/CHANNEL_ID/videos.json?pagesize=PAGE_SIZE&page=PREVIOUS_PAGE",
-    "next": "https://api.video.ibm.com/channels/CHANNEL_ID/videos.json?pagesize=PAGE_SIZE&page=NEXT_PAGE"
+    "previous": "https://api.video.ibm.com/users/self/videos.json?pagesize=PAGE_SIZE&page=PREVIOUS_PAGE",
+    "next": "https://api.video.ibm.com/users/self/videos.json?pagesize=PAGE_SIZE&page=NEXT_PAGE"
   }
 }
 ```
@@ -228,7 +228,7 @@ The paging information can be found under the `paging` key. Example:
 ```json
 {
     "paging": {
-        "previous": "https://api.video.ibm.com/CHANNEL_ID/videos.json?pagesize=PAGE_SIZE&page=PREVIOUS_PAGE",
+        "previous": "https://api.video.ibm.com/channels/CHANNEL_ID/videos.json?pagesize=PAGE_SIZE&page=PREVIOUS_PAGE",
         "next": "https://api.video.ibm.com/channels/CHANNEL_ID/videos.json?pagesize=PAGE_SIZE&page=NEXT_PAGE"
     }
 }


### PR DESCRIPTION
## Overview

- __Type:__
  - 🐛Fix

## Problem

Pager docs of user/videos and channel/videos is not accurate


## Solution

Show proper paging examples